### PR TITLE
Drop pathCache on Remove(Dirs)

### DIFF
--- a/s3/public.go
+++ b/s3/public.go
@@ -207,6 +207,10 @@ func (storage *PublishedStorage) Remove(path string) error {
 		Bucket: aws.String(storage.bucket),
 		Key:    aws.String(filepath.Join(storage.prefix, path)),
 	}
+
+    // Dump the cache to prevent reuse of removed files.
+	storage.pathCache = nil
+
 	_, err := storage.s3.DeleteObject(params)
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
@@ -228,6 +232,9 @@ func (storage *PublishedStorage) Remove(path string) error {
 // RemoveDirs removes directory structure under public path
 func (storage *PublishedStorage) RemoveDirs(path string, progress aptly.Progress) error {
 	const page = 1000
+
+    // Dump the cache to prevent reuse of removed files.
+	storage.pathCache = nil
 
 	filelist, _, err := storage.internalFilelist(path, false)
 	if err != nil {


### PR DESCRIPTION
To prevent cache being used of files that are no longer there empty the patchCache.
Ideally it would only remove the actually paths that are being removed, but as S3 can be access by multiple systems is it even ok to rely on a cache?

Signed-off-by: Daan van Gorkum <djvg@djvg.net>

